### PR TITLE
Feat: Exponential Backoff for Rate Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.3.0 (2023-10-25)
+
+### Added
+
+- Implemented optional exponential backoff for rate limit handling. The wait time between retries will now be calculated dynamically based on the number of attempts made, resulting in fewer requests during the rate-limit window. This should help to reduce the risk of account bans. To utilize this feature, set the `ENABLE_EXPONENTIAL_BACKOFF` environment variable to true.
+
+### Changed
+
+- In absence of the `ENABLE_EXPONENTIAL_BACKOFF` setting or when it is set to false, the rate limit handling will default to the previous flat 1-minute retry timeout.
+
+### Notes
+
+- While the new optional feature greatly minimizes the risk of account bans due to rate limit exceptions, it might not be suitable for all use cases due to increased wait times between the retries. Consider your scenario before enabling this feature.
+- Kudos to @alvinmatias69 for the contribution!
+
 ## 2.2.8 (2023-10-17)
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tweet-harvest",
   "description": "A Twitter crawler helper with auth",
-  "version": "2.2.8",
+  "version": "2.3.0",
   "license": "MIT",
   "author": "Helmi Satria",
   "publishConfig": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,7 +3,8 @@ import { parseEnv, z } from "znv";
 
 config();
 
-export const { DEV_ACCESS_TOKEN: ACCESS_TOKEN, HEADLESS_MODE } = parseEnv(process.env, {
+export const { DEV_ACCESS_TOKEN: ACCESS_TOKEN, HEADLESS_MODE, ENABLE_EXPONENTIAL_BACKOFF } = parseEnv(process.env, {
   DEV_ACCESS_TOKEN: z.string().min(1).optional(),
   HEADLESS_MODE: z.boolean().default(true),
+  ENABLE_EXPONENTIAL_BACKOFF: z.boolean().default(false),
 });

--- a/src/features/exponential-backoff.ts
+++ b/src/features/exponential-backoff.ts
@@ -1,0 +1,29 @@
+import { ENABLE_EXPONENTIAL_BACKOFF } from "../env";
+
+// base timeout is 1 minute.
+const baseTimeout = 60_000;
+
+// maximum timeout is 10 minutes.
+const maximumTimeout = 600_000;
+
+// ratio of the exponent function.
+// Set the ratio to 2 to achieve odd number of timeout multiplication
+// e.g. baseTimeout, 3 * baseTimeout, 5 * baseTimeout, etc
+const ratio = 2;
+
+// calculateForRateLimit will return how long the apps should wait until try again
+// when met a rate limit error.
+// Attempt start with `0`
+export const calculateForRateLimit = (attempt: number): number => {
+    // return base timeout if disabled
+    if (!ENABLE_EXPONENTIAL_BACKOFF) {
+        return baseTimeout;
+    }
+
+    const timeout = ratio * attempt * baseTimeout + baseTimeout;
+
+    // if timeout exceed maximum, return the maximum timeout
+    return timeout > maximumTimeout
+        ? maximumTimeout
+        : timeout;
+}


### PR DESCRIPTION
Currently, tweet-harvest will wait for a minute before retry when rate limit exception got raised. While this approach has the advantage of minimal wait time. It also has a risk to get banned as the request keep coming while getting rate limited.

This PR proposed using exponential backoff algorithm to calculate the timeout for each rate limit exception. Using this approach, the wait time will be calculated dynamically based on the number of attempt's done. Take a look at below example.

Let's say that the rate-limit window is 10 minutes. Using the old approach, tweet-harvest will request 10 times during rate-limit window. On this approach will request only 3 times (1, 3, 5 minutes timeout). While the number isn't that significant, if the rate-limit is increased to let's say 30 minutes the number will grow significantly. Remember, the more request made during rate-limit window, the greater the chance of your account getting banned.

That being said, this approach isn't suitable for all use case. That's why the usage of it is optional. To use exponential backoff for rate-limit, `ENABLE_EXPONENTIAL_BACKOFF` environment variable must be set to true. Otherwise, the timeout will use flat 1 minute, same as before.

Reference:
- [Exponential Backoff for Rate Limit](https://en.wikipedia.org/wiki/Exponential_backoff#Rate_limiting)