### PR TITLE
Memperpanjang waktu Timeout crawling data

### DIFF
--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -124,7 +124,7 @@ export async function crawl({
   });
 
   const page = await context.newPage();
-  page.setDefaultTimeout(60 * 1000);
+  page.setDefaultTimeout(1200 * 1000);
 
   listenNetworkRequests(page);
 


### PR DESCRIPTION
Menambahkan waktu setDefaultTimeout() yang dari 1 menit menjadi 20 menit, agar dapat melakukan crawling data lagi setelah terkena limit 10 menit dari twitter