### PR TITLE
fix(cli): remove ambiguous short option for --to flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.1 (2025-12-16)
+
+### Fixed
+
+- Removed ambiguous `-to` short option from the `--to` CLI flag to prevent command-line parsing conflicts
+
 ## 2.7.0 (2025-12-15)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tweet-harvest",
   "description": "A Twitter crawler helper with auth",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "license": "MIT",
   "author": "Helmi Satria",
   "publishConfig": {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -15,7 +15,7 @@ program.name("npx tweet-harvest").version(version);
 program
   .addOption(new Option("-t, --token <type>", "Twitter auth token"))
   .addOption(new Option("-f, --from <type>", "From date (DD-MM-YYYY)"))
-  .addOption(new Option("-to, --to <type>", "To date (DD-MM-YYYY)"))
+  .addOption(new Option("--to <type>", "To date (DD-MM-YYYY)"))
   .addOption(new Option("-s, --search-keyword <type>", "Search keyword"))
   .addOption(new Option("--thread <type>", "Tweet thread URL"))
   .addOption(new Option("-l, --limit <number>", "Limit number of tweets to crawl").argParser(parseInt))


### PR DESCRIPTION
- In src/bin.ts, removed the '-to' short option for the '--to' CLI flag.
- The '-to' short option was ambiguous and could conflict with other flags or parsing.
- The '--to' flag now only uses its long form, ensuring clear command-line parsing.
- Updated package.json to version 2.7.1 as part of the fix.
- Added changelog entry for version 2.7.1.

Impact:
- Users will now use '--to' instead of '-to' when specifying a 'To date' on the command line.
- This resolves potential issues with CLI parsing of arguments.